### PR TITLE
Fixed the behavior of animated translations

### DIFF
--- a/src/StyleSheet/index.js
+++ b/src/StyleSheet/index.js
@@ -3,6 +3,7 @@ const generateCss = require('./generateCss');
 const murmurHash = require('./murmurHash');
 const injector = require('./injector');
 const mapKeyValue = require('../util/mapKeyValue');
+const processTransform = require('./processTransform');
 
 // TODO:
 // 1. (done) browser-prefixed styles (inline-style-prefixer)
@@ -179,9 +180,11 @@ const flattenClassNames = (input) => {
 
 const resolve = (styles) => ({
   className: flattenClassNames(styles),
-  style: flattenStyle(styles), // TODO(lmr): do we need expandStyle and processTransform here?
+  // TODO(lmr): do we need expandStyle and processTransform here?
+  style: processTransform(returnCopy(styles, flattenStyle(styles))),
 });
 
+const returnCopy = (original, result) => original === result ? Object.assign({}, result) : result;
 
 module.exports = {
   hairlineWidth: getHairlineWidth(),
@@ -189,7 +192,7 @@ module.exports = {
   // NOTE:
   // `flatten` is exported separately from `resolve` because it mimics the RN api more closely
   // than `resolve`.
-  flatten: style => flattenStyle(style) || {},
+  flatten: style => returnCopy(style, flattenStyle(style)) || {},
   resolve,
 
   // NOTE: direct use of this method is for testing only...

--- a/src/StyleSheet/normalizeValue.js
+++ b/src/StyleSheet/normalizeValue.js
@@ -23,6 +23,9 @@ const unitlessNumbers = {
   strokeDashoffset: true,
   strokeOpacity: true,
   strokeWidth: true,
+  scaleX: true,
+  scaleY: true,
+  scaleZ: true,
 };
 
 const normalizeValue = (property, value) => {

--- a/src/StyleSheet/processTransform.js
+++ b/src/StyleSheet/processTransform.js
@@ -1,9 +1,11 @@
+const normalizeValue = require('./normalizeValue');
 // { scale: 2 } => 'scale(2)'
 const mapTransform = (transform) => {
   const key = Object.keys(transform)[0];
-  return `${key}(${transform[key]})`;
+  return `${key}(${normalizeValue(key, transform[key])})`;
 };
 
+// mutative
 const processTransform = (style) => {
   /* eslint no-param-reassign:0 */
   if (style && style.transform) {

--- a/src/UIManager.js
+++ b/src/UIManager.js
@@ -49,7 +49,7 @@ const UIManager = {
           break;
         case 'class':
         case 'className':
-          // prevent class names managed by React Native from being replaced
+          // prevent class names managed by React from being replaced
           node.setAttribute('class', `${node.getAttribute('class')} ${value}`);
           break;
         case 'text':

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,8 @@ const Image = require('./Image/Image');
 const StyleSheet = require('./StyleSheet');
 const Touchable = require('./Touchable/Touchable');
 
+Animated.inject.FlattenStyle(StyleSheet.flatten);
+
 module.exports = {
   Animated: {
     ...Animated,


### PR DESCRIPTION
Couple of problems that I fixed to get this working:

1. `processTransform` was mutative, while the expectation was that `StyleSheet.flatten` is not.  I ended up fixing it so that `StyleSheet.flatten`. It is now guaranteed to return an object different from the one passed in.
2. We were forgetting to `processTransform` in `StyleSheet.resolve`
3. `processTransform` didn't correctly normalize the values to pixels for transforms that are not unitless
4. We weren't injecting `FlattenStyle` into `animated` like we were supposed to.

cc @wyattdanger 