### PR TITLE
Fix StyleSheet corner cases for correctness

### DIFF
--- a/src/StyleSheet/injector.js
+++ b/src/StyleSheet/injector.js
@@ -17,7 +17,6 @@ const getStyleText = () => {
   return result;
 };
 
-
 const frame = () => {
   if (!isDirty) return;
   if (!global.document) return;


### PR DESCRIPTION
This PR fixes two of the major corner cases that the stylesheet implementation didn't solve before as a result of moving to CSS class names for performance:

**1. registered styles overriding other registered styles**
```jsx
const styles = StyleSheet.create({
  red: {
    backgroundColor: 'red',
  },
  green: {
    backgroundColor: 'green',
  },
});
const Green = () => (
  <View>
    <View = style={[styles.red, styles.green]} />
    <View = style={[styles.green, styles.red]} />
  </View>
);
```

The above would result in two green views, since both classes would have the same specificity, it would be a race condition for whichever style ended up furthest at the bottom of the rendered stylesheet.

In order to fix, we now actually create class names for each style rule as well as each possible "position" it could end up in a style prop array.  If it shows up in position `2`, we create a rule for it like `.foo2.foo2` (which has specificity 2) and similarly for position `3` we create a rule for it like `.foo3.foo3`. This ends up with the correct semantics. Since CSS lets us specify multiple selectors per declaration, this ends up not taking up much extra space, and is pretty easy to do.

**2. registered styles overriding inline styles**

```jsx
const styles = StyleSheet.create({
  red: {
    backgroundColor: 'red',
  },
});
const Blue = () => (
  <View>
    <View = style={[{ backgroundColor: 'blue' }, styles.red]} />
  </View>
);
```
Previously, the above would render a blue view instead of a red view, because the inline style would always win.

Since this particular corner case ends up being less common in practice, we end up detecting situations where a registered style shows up in a position after an inline style, and we "deoptimize" in this case, and just render the whole flattened style object as an inline style.

