### PR TITLE
Add StyleSheet.resolve method for web target

### DIFF
--- a/src/injection/react-native-web.js
+++ b/src/injection/react-native-web.js
@@ -10,14 +10,24 @@ const {
   Dimensions,
   Easing,
 } = require('react-native-web');
+const StyleRegistry = require('react-native-web/dist/apis/StyleSheet/registry');
+
+const emptyObject = {};
+
+const resolve = style => {
+  return StyleRegistry.resolveStyle(style) || emptyObject;
+};
 
 ReactPrimitives.inject({
-  StyleSheet,
   View,
   Text,
   Image,
   Easing,
   Animated,
+  StyleSheet: {
+    ...StyleSheet,
+    resolve,
+  },
   Platform: {
     OS: Platform.OS,
     Version: Platform.Version,


### PR DESCRIPTION
to: @jlongster

This is needed to keep backwards compatibility with the deprecated RP web implementation, and I think is just generally a good idea to expose this for people wanting to implement custom web modules.