### PR TITLE
Fix React Native production build

### DIFF
--- a/src/modules/Platform.js
+++ b/src/modules/Platform.js
@@ -10,8 +10,10 @@ const Platform = {
     return obj.default;
   },
   inject: platform => {
-    Platform.OS = platform.OS;
-    Platform.Version = platform.Version;
+    // Use bracket accessor notation as workaround for
+    // https://github.com/facebook/metro-bundler/issues/27
+    Platform['OS'] = platform.OS; // eslint-disable-line dot-notation
+    Platform['Version'] = platform.Version; // eslint-disable-line dot-notation
   },
 };
 


### PR DESCRIPTION
Workaround for Metro bundler issue https://github.com/facebook/metro-bundler/issues/27 causing React Native production bundle task to fail. Fixes https://github.com/lelandrichardson/react-primitives/issues/79.

I've submitted a PR https://github.com/facebook/metro-bundler/pull/45 to fix this in Metro, but whether or not it is merged, it would be good to fix this in react-primitives to support React Native versions earlier than whenever that change lands.

## Test case
1. Run `react-native init TestProject`
2. Add `import {Text, View} from 'react-primitives';` in index.ios.js (instead of from 'react-native').
3. Run `react-native bundle --entry-file index.ios.js --bundle-output ./ios/build/main.jsBundle --assets-dest ./ios/build --dev false --platform ios`

Outcome:
```
Property left of AssignmentExpression expected node to be of a type ["LVal"] but instead got "StringLiteral"
```
After this patch, the build should succeed.