### PR TITLE
support React 16, fixes #84

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
   "dependencies": {
     "animated": "^0.1.5",
     "asap": "^2.0.5",
+    "create-react-class": "^15.6.2",
     "deline": "^1.0.4",
     "flexibility": "^2.0.1",
     "inline-style-prefixer": "^2.0.5",

--- a/src/modules/Touchable.js
+++ b/src/modules/Touchable.js
@@ -1,4 +1,5 @@
 const React = require('react');
+const createReactClass = require('create-react-class');
 const PropTypes = require('prop-types');
 const TimerMixin = require('react-timer-mixin');
 
@@ -74,7 +75,7 @@ const Touchable = (
   });
 
   // eslint-disable-next-line react/prefer-es6-class
-  return React.createClass({
+  return createReactClass({
     displayName: 'Touchable',
     propTypes: {
       accessible: PropTypes.bool,

--- a/src/vr/Touchable.js
+++ b/src/vr/Touchable.js
@@ -1,4 +1,5 @@
 const React = require('react');
+const createReactClass = require('create-react-class');
 const PropTypes = require('prop-types');
 const { VrButton } = require('react-vr');
 
@@ -54,7 +55,7 @@ const Touchable = (
   TouchableMixin,
 ) => {
   // eslint-disable-next-line react/prefer-es6-class
-  return React.createClass({
+  return createReactClass({
     displayName: 'Touchable',
     propTypes: {
       accessible: PropTypes.bool,

--- a/src/web/Touchable/Touchable.js
+++ b/src/web/Touchable/Touchable.js
@@ -1,4 +1,5 @@
 const React = require('react');
+const createReactClass = require('create-react-class');
 const TimerMixin = require('react-timer-mixin');
 const TouchableMixin = require('./TouchableMixin');
 const ensurePositiveDelayProps = require('./ensurePositiveDelayProps');
@@ -64,7 +65,7 @@ const Touchable = (Animated, StyleSheet, Platform) => {
   });
 
   // eslint-disable-next-line react/prefer-es6-class
-  return React.createClass({
+  return createReactClass({
     displayName: 'Touchable',
     propTypes: {
       accessible: PropTypes.bool,


### PR DESCRIPTION
replace `React.createClass` with `create-react-class` to support React 16 as discussed in https://github.com/lelandrichardson/react-primitives/issues/84