### PR TITLE
Use the default export of `StyleRegistry`

### DIFF
--- a/src/injection/react-native-web.js
+++ b/src/injection/react-native-web.js
@@ -10,7 +10,7 @@ const {
   Dimensions,
   Easing,
 } = require('react-native-web');
-const StyleRegistry = require('react-native-web/dist/apis/StyleSheet/registry');
+const StyleRegistry = require('react-native-web/dist/apis/StyleSheet/registry').default;
 
 const emptyObject = {};
 


### PR DESCRIPTION
Looks like `.default` needs to be accessed on the `StyleRegistry` module per: https://github.com/necolas/react-native-web/blob/ad3dee0204df683642ab8cc66bfa9899b27f616a/src/apis/StyleSheet/registry.js#L13

Ran into this while trying to call `resolve()`. It errors saying “undefined is not a function.”