### PR TITLE
Inject Touchable from react-native

### DIFF
--- a/src/injection/react-native.js
+++ b/src/injection/react-native.js
@@ -8,6 +8,7 @@ const {
   Platform,
   Easing,
   Dimensions,
+  Touchable
 } = require('react-native');
 
 ReactPrimitives.inject({
@@ -22,5 +23,5 @@ ReactPrimitives.inject({
     Version: Platform.Version,
   },
   Dimensions,
-  Touchable: require('../modules/Touchable')(Animated, StyleSheet, Platform),
+  Touchable: require('../modules/Touchable')(Animated, StyleSheet, Platform, Touchable.Mixin),
 });


### PR DESCRIPTION
Fixing
`TypeError: undefined is not a function (evaluating 'this.touchableGetInitialState()')`