### PR TITLE
updated rnw to work with next.js ssr

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "normalize-css-color": "^1.0.1",
     "prop-types": "^15.5.10",
     "react-art": "^16.4.0",
-    "react-native-web": "^0.8.3",
+    "react-native-web": "^0.9.5",
     "react-timer-mixin": "^0.13.3",
     "string-hash": "^1.1.3"
   },


### PR DESCRIPTION
in order to properly use react-primitives in next.js we need to use a newer version of react-native-web that has solved some of the issues with SSR