### PR TITLE
Cleanup dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,9 +74,9 @@
   },
   "dependencies": {
     "animated": "^0.2.2",
-    "create-react-class": "^15.6.2",
-    "prop-types": "^15.5.10",
-    "react-timer-mixin": "^0.13.3"
+    "create-react-class": "^15.6.3",
+    "prop-types": "^15.7.2",
+    "react-timer-mixin": "^0.13.4"
   },
   "peerDependencies": {
     "react": ">=16.5.1",

--- a/package.json
+++ b/package.json
@@ -74,15 +74,9 @@
   },
   "dependencies": {
     "animated": "^0.2.2",
-    "asap": "^2.0.5",
     "create-react-class": "^15.6.2",
-    "flexibility": "^2.0.1",
-    "inline-style-prefixer": "^4.0.2",
-    "invariant": "^2.2.1",
-    "normalize-css-color": "^1.0.1",
     "prop-types": "^15.5.10",
-    "react-timer-mixin": "^0.13.3",
-    "string-hash": "^1.1.3"
+    "react-timer-mixin": "^0.13.3"
   },
   "peerDependencies": {
     "react": ">=16.5.1",


### PR DESCRIPTION
* remove dependencies no longer needed
    - asap
    - flexibility
    - inline-style-prefixer
    - invariant
    - normalize-css-color
    - react-timer-mixin
    - string-hash

* Update minimum version of some remaining dependencies (this should not be an effective change, just thought it would be a little cleaner):
    - create-react-class@^15.6.3
    - prop-types@^15.7.2
    - react-timer-mixin@^0.13.4"

I did a grep of each dependency on the following JavaScript file patterns before removing:
- `*.js`
- `src/*`
- `src/*/*`

## How tested

I did `yarn run:webpack` and verified that everything on `example/web/example.html` continues to work without the removed dependencies.

I had some trouble with a react-native example build on both Android and iOS, would like to try it on expo build in the near future (see #132). I do not expect that any issues should be revealed by a react-native or expo example build.