### PR TITLE
Named functions in Touchable.js & vr/Touchable.js

### DIFF
--- a/src/modules/Touchable.js
+++ b/src/modules/Touchable.js
@@ -26,7 +26,7 @@ const THROTTLE_MS = 500;
 function throttle(fn, throttleMs) {
   let lastCall = null;
 
-  return function (...args) {
+  return function throttleIt(...args) {
     const now = new Date();
     if (lastCall === null || (now - lastCall > throttleMs)) {
       fn.apply(this, args);
@@ -192,7 +192,7 @@ const Touchable = (
      * `Touchable.Mixin` self callbacks. The mixin will invoke these if they are
      * defined on your component.
      */
-    touchableHandleActivePressIn: throttle(function (e) {
+    touchableHandleActivePressIn: throttle(function touchableHandleActivePressInNow(e) {
       if (e.dispatchConfig.registrationName === 'onResponderGrant') {
         this._setActive(0);
       } else {
@@ -202,18 +202,18 @@ const Touchable = (
       this.props.onPressIn && this.props.onPressIn(e);
     }, THROTTLE_MS),
 
-    touchableHandleActivePressOut: throttle(function (e) {
+    touchableHandleActivePressOut: throttle(function touchableHandleActivePressOutNow(e) {
       this._setInactive(250);
       // eslint-disable-next-line no-unused-expressions
       this.props.onPressOut && this.props.onPressOut(e);
     }, THROTTLE_MS),
 
-    touchableHandlePress: throttle(function (e) {
+    touchableHandlePress: throttle(function touchableHandlePressNow(e) {
       // eslint-disable-next-line no-unused-expressions
       this.props.onPress && this.props.onPress(e);
     }, THROTTLE_MS),
 
-    touchableHandleLongPress: throttle(function (e) {
+    touchableHandleLongPress: throttle(function touchableHandleLongPressNow(e) {
       // eslint-disable-next-line no-unused-expressions
       this.props.onLongPress && this.props.onLongPress(e);
     }, THROTTLE_MS),

--- a/src/vr/Touchable.js
+++ b/src/vr/Touchable.js
@@ -18,7 +18,7 @@ const THROTTLE_MS = 500;
 function throttle(fn, throttleMs) {
   let lastCall = null;
 
-  return function (...args) {
+  return function throttleIt(...args) {
     const now = new Date();
     if (lastCall === null || (now - lastCall > throttleMs)) {
       fn.apply(this, args);
@@ -157,24 +157,24 @@ const Touchable = (
     },
 
 
-    touchableHandleActivePressIn: throttle(function (e) {
+    touchableHandleActivePressIn: throttle(function touchableHandleActivePressInNow(e) {
       this._setActive(150);
       // eslint-disable-next-line no-unused-expressions
       this.props.onPressIn && this.props.onPressIn(e);
     }, THROTTLE_MS),
 
-    touchableHandleActivePressOut: throttle(function (e) {
+    touchableHandleActivePressOut: throttle(function touchableHandleActivePressOutNow(e) {
       this._setInactive(250);
       // eslint-disable-next-line no-unused-expressions
       this.props.onPressOut && this.props.onPressOut(e);
     }, THROTTLE_MS),
 
-    touchableHandlePress: throttle(function (e) {
+    touchableHandlePress: throttle(function touchableHandlePressNow(e) {
       // eslint-disable-next-line no-unused-expressions
       this.props.onPress && this.props.onPress(e);
     }, THROTTLE_MS),
 
-    touchableHandleLongPress: throttle(function (e) {
+    touchableHandleLongPress: throttle(function touchableHandleLongPressNow(e) {
       // eslint-disable-next-line no-unused-expressions
       this.props.onLongPress && this.props.onLongPress(e);
     }, THROTTLE_MS),


### PR DESCRIPTION
to resolve the lint warnings

Quick test of `example/web/example.html` on my Chrome (Canary) browser seemed to work properly with these changes.