### PR TITLE
Add react-figma platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ You will also need to install the targets you want to support:
   ```
 - figma:
   ```sh
-  npm install --save react-figma
+  npm install --save react-figma yoga-layout-prebuilt
   ```
 - vr:
   ```sh

--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ You will also need to install the targets you want to support:
   ```sh
   npm install --save react-sketchapp react-test-renderer
   ```
+- figma:
+  ```sh
+  npm install --save react-figma
+  ```
 - vr:
   ```sh
   npm install --save react-360

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "react-360": "^1.1.0",
     "react-art": "^16.5.2",
     "react-dom": "^16.5.2",
+    "react-figma": "0.0.57",
     "react-native": "^0.52.0",
     "react-native-web": "^0.11.0",
     "react-sketchapp": "^2.0.0",

--- a/src/index.figma.js
+++ b/src/index.figma.js
@@ -1,0 +1,3 @@
+require('./injection/react-figma');
+
+module.exports = require('./ReactPrimitives');

--- a/src/injection/react-figma.js
+++ b/src/injection/react-figma.js
@@ -1,0 +1,53 @@
+const ReactPrimitives = require('../ReactPrimitives');
+const Animated = require('animated');
+const Easing = require('animated/lib/Easing');
+const {
+  View,
+  Text,
+  Image,
+  StyleSheet,
+  // TODO(lmr): Dimensions
+} = require('react-figma');
+
+const TouchableMixin = {
+  componentWillUnmount() {},
+  touchableGetInitialState() {
+    return { touchable: { touchState: undefined, responderID: null } };
+  },
+  touchableHandleResponderTerminationRequest() { return false; },
+  touchableHandleStartShouldSetResponder() { return false; },
+  touchableLongPressCancelsPress() { return true; },
+  touchableHandleResponderGrant() {},
+  touchableHandleResponderRelease() {},
+  touchableHandleResponderTerminate() {},
+  touchableHandleResponderMove() {},
+};
+
+Animated.inject.FlattenStyle(StyleSheet.flatten);
+
+ReactPrimitives.inject({
+  StyleSheet,
+  View,
+  Text,
+  Image,
+  Easing,
+  Animated: {
+    ...Animated,
+    View: Animated.createAnimatedComponent(View),
+    Text: Animated.createAnimatedComponent(Text),
+    Image: Animated.createAnimatedComponent(Image),
+  },
+  Platform: {
+    OS: 'figma',
+    Version: 1,
+  },
+});
+
+ReactPrimitives.inject({
+  Touchable: require('../modules/Touchable')(
+    Animated,
+    StyleSheet,
+    ReactPrimitives.Platform,
+    TouchableMixin,
+  ),
+});


### PR DESCRIPTION
Adds `react-figma` as a new platform.

(there's a Webpack resolve issue though, where the react-native-web `index.js` is resolved before `.figma.js`, as `.figma.js` is not in the config `extensions`: I've opened an issue at https://github.com/react-figma/webpack-config , so probably worth waiting for that before merging this, as a node_module injection is needed for now).

Example library using this PR: https://github.com/macintoshhelper/react-figma-styled-components

resolves #142 