### PR TITLE
Support RNW 0.18, remove StyleSheet.resolve API. Refs #147

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "react-dom": "^16.5.2",
     "react-figma": "0.0.57",
     "react-native": "^0.52.0",
-    "react-native-web": "^0.18.10",
+    "react-native-web": "^0.11.0",
     "react-sketchapp": "^2.0.0",
     "react-test-renderer": "^16.4.0",
     "watchify": "^3.7.0",
@@ -83,6 +83,6 @@
     "react": ">=16.5.1",
     "react-art": ">=16.5.1",
     "react-dom": ">=16.5.1",
-    "react-native-web": ">=0.18.10"
+    "react-native-web": ">=0.11.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "react-dom": "^16.5.2",
     "react-figma": "0.0.57",
     "react-native": "^0.52.0",
-    "react-native-web": "^0.11.0",
+    "react-native-web": "^0.18.10",
     "react-sketchapp": "^2.0.0",
     "react-test-renderer": "^16.4.0",
     "watchify": "^3.7.0",
@@ -83,6 +83,6 @@
     "react": ">=16.5.1",
     "react-art": ">=16.5.1",
     "react-dom": ">=16.5.1",
-    "react-native-web": ">=0.11.0"
+    "react-native-web": ">=0.18.10"
   }
 }

--- a/src/injection/react-native-web.js
+++ b/src/injection/react-native-web.js
@@ -11,30 +11,13 @@ const {
   Easing,
 } = require('react-native-web');
 
-// TODO: figure out a more appropriate way to get StyleSheet.resolve, or potentially remove the
-// API alltogether.
-function getDefault(m) {
-  return m.__esModule === true ? m.default : m;
-}
-
-const StyleRegistry = getDefault(require('react-native-web/dist/cjs/exports/StyleSheet/createStyleResolver'))();
-
-const emptyObject = {};
-
-const resolve = style => {
-  return StyleRegistry.resolve(style) || emptyObject;
-};
-
 ReactPrimitives.inject({
   View,
   Text,
   Image,
   Easing,
   Animated,
-  StyleSheet: {
-    ...StyleSheet,
-    resolve,
-  },
+  StyleSheet,
   Platform: {
     OS: Platform.OS,
     Version: Platform.Version,


### PR DESCRIPTION
Fixes #147 
Fixes #139 

This change adds support for RNW 0.18. Refer to #139 for notes on why we should remove the `Stylesheet.resolve` API.

[RNW 0.18](https://github.com/necolas/react-native-web/releases/tag/0.18.0) has changed its stylesheet implementation to closely match RN.  

That RNW change is required to fix a bug in the emotion library (see https://github.com/emotion-js/emotion/issues/1543).

The final piece of the puzzle is to upgrade react-primitives to support RNW 0.18. The react-primitives upgrade is blocking us from fixing that emotion bug. 